### PR TITLE
Add role to stub provider login workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ If you want to run without starting Azurite, then the other settings can be set.
 
 ```
 {
-  "StubProviderAuth": true,
+  "StubProviderAuth": false,
   "SqlConnectionString": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=TLevelProviders;Integrated Security=True;MultipleActiveResultSets=True;",
   "DfeSignInSettings": {
   },

--- a/src/Sfa.Tl.Find.Provider.Web/Authorization/ProviderStubAuthHandler.cs
+++ b/src/Sfa.Tl.Find.Provider.Web/Authorization/ProviderStubAuthHandler.cs
@@ -26,7 +26,8 @@ public class ProviderStubAuthHandler : AuthenticationHandler<AuthenticationSchem
         var claims = new[]
         {
             new Claim(CustomClaimTypes.DisplayName, "Test User"),
-            new Claim(CustomClaimTypes.UkPrn, "10000001")
+            new Claim(CustomClaimTypes.UkPrn, "10000001"),
+            new Claim(ClaimTypes.Role, CustomRoles.ProviderEndUser)
         };
         var identity = new ClaimsIdentity(claims, "Provider-stub");
         var principal = new ClaimsPrincipal(identity);


### PR DESCRIPTION
Fixes issue where a developer can use stub authentication on a local development instance but has no roles.