### PR TITLE
Feature/add roles to developer login workaround

### DIFF
--- a/api-definitions/findaproviderapi.json
+++ b/api-definitions/findaproviderapi.json
@@ -661,28 +661,6 @@
         }
       }
     },
-    "/api/v{version}/jobtriggers/startuptasks": {
-      "post": {
-        "tags": [
-          "JobTriggers"
-        ],
-        "parameters": [
-          {
-            "name": "version",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          }
-        }
-      }
-    },
     "/api/v{version}/jobtriggers/importtowns": {
       "post": {
         "tags": [

--- a/src/Sfa.Tl.Find.Provider.Api.UnitTests/Controllers/JobTriggersControllerTests.cs
+++ b/src/Sfa.Tl.Find.Provider.Api.UnitTests/Controllers/JobTriggersControllerTests.cs
@@ -116,26 +116,7 @@ public class JobTriggersControllerTests
             .TriggerJob(Arg.Is<JobKey>(k =>
                 k.Name == JobKeys.ProviderNotificationEmailWeekly));
     }
-
-    [Fact]
-    public async Task TriggerStartupTasksJob_Runs_Job()
-    {
-        var scheduler = Substitute.For<IScheduler>();
-        var schedulerFactory = Substitute.For<ISchedulerFactory>();
-        schedulerFactory.GetScheduler()
-            .Returns(Task.FromResult(scheduler));
-
-        var controller = new JobTriggersControllerBuilder()
-            .Build(schedulerFactory);
-
-        await controller.TriggerStartupTasksJob();
-
-        await scheduler
-            .Received(1)
-            .TriggerJob(Arg.Is<JobKey>(k => 
-                k.Name == JobKeys.StartupTasks));
-    }
-
+    
     [Fact]
     public async Task TriggerImportTownDataJob_Runs_Job()
     {

--- a/src/Sfa.Tl.Find.Provider.Api/Controllers/JobTriggersController.cs
+++ b/src/Sfa.Tl.Find.Provider.Api/Controllers/JobTriggersController.cs
@@ -50,11 +50,6 @@ public class JobTriggersController : ControllerBase
         await TriggerJob(JobKeys.ProviderNotificationEmailWeekly);
     
     [HttpPost]
-    [Route("startuptasks")]
-    public async Task TriggerStartupTasksJob() =>
-        await TriggerJob(JobKeys.StartupTasks);
-
-    [HttpPost]
     [Route("importtowns")]
     public async Task TriggerImportTownDataJob() => 
         await TriggerJob(JobKeys.ImportTownData);

--- a/src/Sfa.Tl.Find.Provider.Application/Models/JobKeys.cs
+++ b/src/Sfa.Tl.Find.Provider.Application/Models/JobKeys.cs
@@ -8,5 +8,4 @@ public static class JobKeys
     public const string ProviderNotificationEmailImmediate = "Provider Notification Emails - Immediate";
     public const string ProviderNotificationEmailDaily = "Provider Notification Emails - Daily";
     public const string ProviderNotificationEmailWeekly = "Provider Notification Emails - Weekly";
-    public const string StartupTasks = "Perform Startup Tasks";
 }

--- a/src/Sfa.Tl.Find.Provider.Web/Authorization/DataProtectionExtensions.cs
+++ b/src/Sfa.Tl.Find.Provider.Web/Authorization/DataProtectionExtensions.cs
@@ -12,9 +12,16 @@ public static class DataProtectionExtensions
 
     public static IServiceCollection AddWebDataProtection(
         this IServiceCollection services,
-        SiteConfiguration configuration)
+        SiteConfiguration configuration,
+        IWebHostEnvironment env)
     {
-        if (!string.IsNullOrEmpty(configuration.BlobStorageConnectionString))
+        if (env.IsDevelopment())
+        {
+            services.AddDataProtection()
+                .PersistKeysToFileSystem(new DirectoryInfo(Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "keys")))
+                .SetApplicationName("TLevelsConnect");
+        }
+        else if (!string.IsNullOrEmpty(configuration.BlobStorageConnectionString))
         {
             services.AddDataProtection()
                 .PersistKeysToAzureBlobStorage(

--- a/src/Sfa.Tl.Find.Provider.Web/Authorization/ProviderStubAuthHandler.cs
+++ b/src/Sfa.Tl.Find.Provider.Web/Authorization/ProviderStubAuthHandler.cs
@@ -26,7 +26,7 @@ public class ProviderStubAuthHandler : AuthenticationHandler<AuthenticationSchem
         var claims = new[]
         {
             new Claim(CustomClaimTypes.DisplayName, "Test User"),
-            new Claim(CustomClaimTypes.UkPrn, "10000001"),
+            new Claim(CustomClaimTypes.UkPrn, "10000055"),
             new Claim(ClaimTypes.Role, CustomRoles.ProviderEndUser)
         };
         var identity = new ClaimsIdentity(claims, "Provider-stub");

--- a/src/Sfa.Tl.Find.Provider.Web/Program.cs
+++ b/src/Sfa.Tl.Find.Provider.Web/Program.cs
@@ -40,7 +40,7 @@ if (bool.TryParse(builder.Configuration[ConfigurationConstants.SkipProviderAuthe
 else
 {
     builder.Services.AddProviderAuthentication(siteConfiguration.DfeSignInSettings!, builder.Environment);
-    builder.Services.AddWebDataProtection(siteConfiguration);
+    builder.Services.AddWebDataProtection(siteConfiguration, builder.Environment);
 }
 
 builder.Services.AddSingleton<IAuthorizationHandler, AdministratorAuthorizationHandler>();


### PR DESCRIPTION
- Update stub provider login workaround to include roles and real UKPRN for developer local use
- Use local file system to store data protection keys on developer machines
- Remove unused startup job name and trigger endpoint