### PR TITLE
Added key vault name to sql server template

### DIFF
--- a/azure/findproviderapi-shared.json
+++ b/azure/findproviderapi-shared.json
@@ -217,6 +217,52 @@
             ]
         },
         {
+            "apiVersion": "2022-09-01",
+            "name": "[concat('key-vault-secret-',parameters('environmentNameAbbreviation'), '-admin-username')]",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'), 'keyvault-secret.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "keyVaultName": {
+                        "value": "[variables('keyVaultName')]"
+                    },
+                    "secretName": {
+                        "value": "[concat(variables('sqlServerName'),'-admin-username')]"
+                    },
+                    "secretValue": {
+                        "value": "[parameters('sqlServerAdminUserName')]"
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2022-09-01",
+            "name": "[concat('key-vault-secret-',parameters('environmentNameAbbreviation'), '-admin-password')]",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'), 'keyvault-secret.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "keyVaultName": {
+                        "value": "[variables('keyVaultName')]"
+                    },
+                    "secretName": {
+                        "value": "[concat(variables('sqlServerName'),'-admin-password')]"
+                    },
+                    "secretValue": {
+                        "value": "[parameters('sqlServerAdminPassword')]"
+                    }
+                }
+            }
+        },
+        {
             "apiVersion": "2017-05-10",
             "name": "[concat('app-service-plan','-', parameters('environmentNameAbbreviation'))]",
             "type": "Microsoft.Resources/deployments",


### PR DESCRIPTION
Changes to tl-platform-building-blocks: https://github.com/SkillsFundingAgency/tl-platform-building-blocks/pull/27 means that a keyvault name needs to be provided to ensure that the sql admin creds get stored in key vault automatically.