### PR TITLE
added github release to build job

### DIFF
--- a/yaml/jobs/findproviderapi-build-application-job.yml
+++ b/yaml/jobs/findproviderapi-build-application-job.yml
@@ -116,3 +116,11 @@ jobs:
           PathtoPublish: '$(build.artifactstagingdirectory)/publish'
           ArtifactName: 'appdrop'
           publishLocation: 'Container'
+
+    - task: GitHubRelease@1
+      displayName: 'GitHub release (create)'
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main') , eq(variables['Build.Reason'], 'IndividualCI'))
+      inputs:
+        gitHubConnection: SkillsFundingAgency
+        tagSource: userSpecifiedTag
+        tag: '$(Build.BuildNumber)'


### PR DESCRIPTION
Added github release task to build job with following conditions:
succeeded() - Will only run after successful build steps.
eq(variables['Build.SourceBranch'], 'refs/heads/main') - Will only run when code is merged to main branch.
eq(variables['Build.Reason'], 'IndividualCI') - Will only run on CI trigger, which is only possible from PR merges into main branch.