### PR TITLE
Rotate Storage Account Access Keys

### DIFF
--- a/azure/findproviderapi-environment.json
+++ b/azure/findproviderapi-environment.json
@@ -437,7 +437,7 @@
         },
         "BlobStorageConnectionString": {
             "type": "string",
-            "value": "[reference(concat('storage-account','-', parameters('environmentNameAbbreviation'))).outputs.storageConnectionString.value]"
+            "value": "[reference(concat('storage-account','-', parameters('environmentNameAbbreviation'))).outputs.storageConnectionStringKey2.value]"
         }
     }
 }

--- a/azure/findproviderapi-shared.json
+++ b/azure/findproviderapi-shared.json
@@ -382,11 +382,11 @@
         },
         "sharedStorageConnectionString": {
             "type": "string",
-            "value": "[reference(concat('shared-storage-account','-', parameters('environmentNameAbbreviation'))).outputs.storageConnectionString.value]"
+            "value": "[reference(concat('shared-storage-account','-', parameters('environmentNameAbbreviation'))).outputs.storageConnectionStringKey2.value]"
         },
         "configStorageConnectionString": {
             "type": "string",
-            "value": "[reference(concat('config-storage-account','-', parameters('environmentNameAbbreviation'))).outputs.storageConnectionString.value]"
+            "value": "[reference(concat('config-storage-account','-', parameters('environmentNameAbbreviation'))).outputs.storageConnectionStringKey2.value]"
         },
         "ConfigStorageAccountName": {
             "type": "string",


### PR DESCRIPTION
This change updates storage account access key outputs in the ARM templates to support the rotation of the keys, by consuming the newly created key2 connection string output that is being constructed in the platform building blocks repository.