### PR TITLE
Rotate access keys for SQL audit logs

### DIFF
--- a/azure/findproviderapi-shared.json
+++ b/azure/findproviderapi-shared.json
@@ -61,6 +61,10 @@
             "type": "int",
             "minValue": 0,
             "maxValue": 6
+        },
+        "isStorageSecondaryKeyInUse": {
+            "type": "bool",
+            "allowedValues": [ "true", "false"]
         }
     },
     "variables": {
@@ -210,14 +214,8 @@
                     "sqlStorageAccountName": {
                         "value": "[variables('sharedStorageAccountName')]"
                     },
-                    "sqlStorageAccountAccessKey1": {
-                        "value": "[reference(concat('shared-storage-account','-',parameters('environmentNameAbbreviation'))).outputs.sqlStorageAccountAccessKey1.value]"
-                    },
-                    "sqlStorageAccountAccessKey2": {
-                        "value": "[reference(concat('shared-storage-account','-',parameters('environmentNameAbbreviation'))).outputs.sqlStorageAccountAccessKey2.value]"
-                    },
                     "isStorageSecondaryKeyInUse": {
-                        "value": "[true()]"
+                        "value": "[parameters('isStorageSecondaryKeyInUse')]"
                     }
                 }
             },

--- a/azure/findproviderapi-shared.json
+++ b/azure/findproviderapi-shared.json
@@ -68,7 +68,7 @@
         }
     },
     "variables": {
-        "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/tl-platform-building-blocks/master/ArmTemplates/",
+        "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/tl-platform-building-blocks/feature/TLD-351-access-key-rotation-for-SQL/ArmTemplates/",
         "resourceNamePrefix": "[toLower(parameters('environmentNameAbbreviation'))]",
         "sqlServerName": "[concat(variables('resourceNamePrefix'), '-shared-sql')]",
         "sharedStorageAccountName": "[replace(concat(variables('resourceNamePrefix'), 'str'), '-', '')]",

--- a/azure/findproviderapi-shared.json
+++ b/azure/findproviderapi-shared.json
@@ -209,6 +209,15 @@
                     },
                     "sqlStorageAccountName": {
                         "value": "[variables('sharedStorageAccountName')]"
+                    },
+                    "sqlStorageAccountAccessKey1": {
+                        "value": "[reference(concat('shared-storage-account','-',parameters('environmentNameAbbreviation'))).outputs.sqlStorageAccountAccessKey1.value]"
+                    },
+                    "sqlStorageAccountAccessKey2": {
+                        "value": "[reference(concat('shared-storage-account','-',parameters('environmentNameAbbreviation'))).outputs.sqlStorageAccountAccessKey2.value]"
+                    },
+                    "isStorageSecondaryKeyInUse": {
+                        "value": "[true()]"
                     }
                 }
             },

--- a/yaml/jobs/findproviderapi-shared-infrastructure-job.yml
+++ b/yaml/jobs/findproviderapi-shared-infrastructure-job.yml
@@ -41,7 +41,8 @@ jobs:
                   -azureWebsitesRPObjectId "$(AzureWebsitesRPObjectId)"
                   -redisCacheSKU "$(RedisCacheSKU)"
                   -redisCacheFamily "$(RedisCacheFamily)"
-                  -redisCacheCapacity "$(RedisCacheCapacity)"'
+                  -redisCacheCapacity "$(RedisCacheCapacity)"
+                  -isStorageSecondaryKeyInUse "$(isStorageSecondaryKeyInUse)"'
                 tags: $(Tags)                
                 processOutputs: true
             - pwsh: Write-Host "##vso[task.setvariable variable=SharedResourceGroup;isOutput=true]$(SharedResourceGroup)"


### PR DESCRIPTION
This change adds references for key1 and key2 for the storage account for the audit logs. Additionally, it sets the current key being used to key2.