### PR TITLE
Rotate access keys for SQL audit log storage

### DIFF
--- a/azure/findproviderapi-shared.json
+++ b/azure/findproviderapi-shared.json
@@ -61,6 +61,10 @@
             "type": "int",
             "minValue": 0,
             "maxValue": 6
+        },
+        "isStorageSecondaryKeyInUse": {
+            "type": "bool",
+            "allowedValues": [ true, false ]
         }
     },
     "variables": {
@@ -209,6 +213,9 @@
                     },
                     "sqlStorageAccountName": {
                         "value": "[variables('sharedStorageAccountName')]"
+                    },
+                    "isStorageSecondaryKeyInUse": {
+                        "value": "[parameters('isStorageSecondaryKeyInUse')]"
                     }
                 }
             },

--- a/yaml/jobs/findproviderapi-shared-infrastructure-job.yml
+++ b/yaml/jobs/findproviderapi-shared-infrastructure-job.yml
@@ -41,7 +41,8 @@ jobs:
                   -azureWebsitesRPObjectId "$(AzureWebsitesRPObjectId)"
                   -redisCacheSKU "$(RedisCacheSKU)"
                   -redisCacheFamily "$(RedisCacheFamily)"
-                  -redisCacheCapacity "$(RedisCacheCapacity)"'
+                  -redisCacheCapacity "$(RedisCacheCapacity)"
+                  -isStorageSecondaryKeyInUse "$(isStorageSecondaryKeyInUse)"'
                 tags: $(Tags)                
                 processOutputs: true
             - pwsh: Write-Host "##vso[task.setvariable variable=SharedResourceGroup;isOutput=true]$(SharedResourceGroup)"


### PR DESCRIPTION
These changes add a parameter "isStorageSecondaryKeyInUse", which is stored as a variable within Azure DevOps variable groups, per service & per environment (**platform-dev-findproviderapi** for example). This can be used to switch between using key1 or key2 when storing SQL audit logs to a storage account.