### PR TITLE
Add Firewall Rules to not be removed from SQL Server

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,8 @@ pr:
   
 
 variables:
-  applicationName: findpvdrapi
+- template: ./Automation/variables/vars-global.yml@devopsTemplates
+- name: applicationName
+  value: findpvdrapi
 stages:
   - template: ./yaml/stages/findproviderapi-master-stage.yml

--- a/azure/findproviderapi-shared.json
+++ b/azure/findproviderapi-shared.json
@@ -65,6 +65,9 @@
         "isStorageSecondaryKeyInUse": {
             "type": "bool",
             "allowedValues": [ true, false ]
+        },
+        "sqlFirewallIpAddressesPredefined": {
+            "type": "array"
         }
     },
     "variables": {
@@ -372,6 +375,29 @@
                     }
                 }
             }
+        },
+        {
+            "apiVersion": "2020-10-01",
+            "name": "[concat('sql-server-firewall-rules','-', parameters('environmentNameAbbreviation'))]",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'),'sql-server-firewall-rules.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "sqlFirewallIpAddressesPredefined": {
+                        "value": "[parameters('sqlFirewallIpAddressesPredefined')]"
+                    },
+                    "serverName": {
+                        "value": "[variables('sqlServerName')]"
+                    }
+                }
+            },
+            "dependsOn": [
+                "[concat('sql-server','-', parameters('environmentNameAbbreviation'))]"
+            ]
         }
     ],
     "outputs": {

--- a/yaml/jobs/findproviderapi-shared-infrastructure-job.yml
+++ b/yaml/jobs/findproviderapi-shared-infrastructure-job.yml
@@ -42,6 +42,7 @@ jobs:
                   -redisCacheSKU "$(RedisCacheSKU)"
                   -redisCacheFamily "$(RedisCacheFamily)"
                   -redisCacheCapacity "$(RedisCacheCapacity)"
+                  -sqlFirewallIpAddressesPredefined $(sqlFirewallIpAddresses)
                   -isStorageSecondaryKeyInUse "$(isStorageSecondaryKeyInUse)"'
                 tags: $(Tags)                
                 processOutputs: true


### PR DESCRIPTION
Add the firewall rules resource and global variable template which includes the IP addresses to not be removed from the SQL Server when the daily clean up job runs. 