### PR TITLE
Revert "Remove app service restrictions from internal API"

### DIFF
--- a/azure/findproviderapi-environment.json
+++ b/azure/findproviderapi-environment.json
@@ -210,8 +210,11 @@
                     "http20Enabled": {
                         "value": true
                     },
+                    "ipSecurityRestrictions": {
+                        "value": "[parameters('ipSecurityRestrictions')]"
+                    },
                     "ipSecurityRestrictionsDefaultAction": {
-                        "value": "Allow"
+                        "value": "Deny"
                     }
                 }
             },


### PR DESCRIPTION
Reverts SkillsFundingAgency/tl-find-provider-api#135

After more testing the FPR internal API doesn't communicate with the front end/UI web app, so this hotfix wasn't necessary as the internal API/ web app service traffic is coming from the WAF. 