### PR TITLE
Update GitVersion

### DIFF
--- a/yaml/jobs/findproviderapi-build-application-job.yml
+++ b/yaml/jobs/findproviderapi-build-application-job.yml
@@ -14,12 +14,6 @@ jobs:
         packageType: 'sdk'
         version: '2.1.x'
 
-    - task: GitVersion@5
-      displayName: GitVersion
-      inputs:
-        runtime: 'core'
-        updateAssemblyInfo: true
-
     - task: NodeTool@0
       displayName: 'Node install'
       inputs:
@@ -37,6 +31,16 @@ jobs:
         packageType: sdk
         version: $(dotnetVersion)
         installationPath: $(Agent.ToolsDirectory)/dotnet
+
+    - task: gitversion/setup@3.1.1
+      displayName: Install GitVersion
+      inputs:
+        versionSpec: '6.0.x'
+
+    - task: gitversion/execute@3.1.1
+      displayName: Update GitVersion
+      inputs:
+        updateAssemblyInfo: true
 
     - task: Gulp@0
       displayName: gulp


### PR DESCRIPTION
Updates GitVersion to use GitTools due to the former being dependent on a version of Node that is now EoL.