### PR TITLE
Update Generate Config & Deployment Tasks

### DIFF
--- a/azure/findproviderapi-shared.json
+++ b/azure/findproviderapi-shared.json
@@ -446,7 +446,10 @@
         "SqlUserIdentityResourceId": {
             "type": "string",
             "value": "[reference(concat('sql-server','-', parameters('environmentNameAbbreviation'))).outputs.sqlUserIdentityResourceId.value]"
+        },
+        "RedisConnectionString": {
+            "type": "string",
+            "value": "[concat(variables('redisCacheName'), '.redis.cache.windows.net:6380,password=',listKeys(resourceId('Microsoft.Cache/Redis', variables('redisCacheName')), '2016-04-01').primaryKey ,',ssl=True,abortConnect=False')]"
         }
-
     }
 }

--- a/yaml/jobs/findproviderapi-generate-configs-job.yml
+++ b/yaml/jobs/findproviderapi-generate-configs-job.yml
@@ -6,14 +6,19 @@ parameters:
   - name: tableName
     type: string
     default: 'configuration'
+  - name: environmentName
+    type: string
+  - name: ConfigurationSecrets
+    type: object
+    default: {}
 jobs:
 - job: GenerateConfigs
   variables:
     ConfigStorageAccountName:     $[ stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.armOutputs.armOutput.ConfigStorageAccountName'] ]
     SqlConnectionString:          $[ dependencies.DeploySQLDatabase.outputs['SqlVariables.SqlConnectionString'] ]
     BlobStorageConnectionString : $[ dependencies.DeployfindproviderapiInfrastructure.outputs['armOutputs.armOutput.BlobStorageConnectionString'] ]
-    RedisCacheName:               $[ stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.armOutputs.armOutput.RedisCacheName'] ]
-    
+    RedisCacheConnectionString:   $[ stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.armOutputs.armOutput.RedisConnectionString'] ]
+
   pool:
     name: 'Azure Pipelines'
     vmImage: 'windows-2019'
@@ -21,31 +26,29 @@ jobs:
     - DeployfindproviderapiInfrastructure
     - DeploySQLDatabase
   steps:
-    - task: AzurePowerShell@5
-      inputs: 
-        azurePowerShellVersion: 'LatestVersion'
-        azureSubscription: ${{ parameters.serviceConnection }}
-        scriptType: 'InlineScript'
-        Inline: |
-          $variableName = "RedisCacheConnectionString"
-          Write-Host "Obtaining the connection string for $(RedisCacheName) and setting $variableName"
-          $redisCache = Get-AzRedisCache -Name $(RedisCacheName)
-          $primaryKey = (Get-AzRedisCacheKey -Name $(RedisCacheName)).PrimaryKey
-          $connectionString = $redisCache.HostName + ":" + $redisCache.SslPort + ",password=" + $primaryKey + ",ssl=True,abortConnect=False"
-          Write-Output "##vso[task.setvariable variable=$variableName;issecret=true]$connectionString"
-          Write-Host "Variable $variableName set"
-
+    - checkout: self
+    - checkout: devopsTools
     - task: DownloadBuildArtifacts@0
       inputs:
         buildType: 'current'
         downloadType: 'single'
         artifactName: 'appdrop'
         downloadPath: '$(System.ArtifactsDirectory)'
-    
-    - task: GenerateEnvironmentConfiguration@3
-      displayName: 'Process schemas in $(System.ArtifactsDirectory)/appdrop/config'
+
+    - task: AzurePowerShell@5
+      displayName: 'Generate Configuration'
       inputs:
-        SourcePath: '$(System.ArtifactsDirectory)/appdrop/config'
-        ServiceConnectionName: ${{ parameters.serviceConnection}}
-        StorageAccountName: '$(ConfigStorageAccountName)'
-        TableName: Configuration
+        azureSubscription: ${{ parameters.ServiceConnection }}
+        ScriptType: 'FilePath'
+        scriptPath: './operations-devops-tools/Powershell/GenerateConfig/New-ConfigurationTableEntry.ps1'
+        scriptArguments:
+          -SourcePath "$(System.ArtifactsDirectory)/appdrop/config"
+          -TargetFilename "*.schema.json"
+          -StorageAccountName "$(ConfigStorageAccountName)"
+          -StorageAccountResourceGroup "$(SharedResourceGroup)"
+          -EnvironmentName ${{ parameters.environmentName }}
+          -TableName "Configuration"
+        azurePowerShellVersion: LatestVersion
+        pwsh: true
+        FailOnStandardError: true
+      env: ${{ parameters.ConfigurationSecrets }}

--- a/yaml/jobs/findproviderapi-publish-site-job.yml
+++ b/yaml/jobs/findproviderapi-publish-site-job.yml
@@ -36,7 +36,7 @@ jobs:
       artifactName: 'appdrop'
       downloadPath: '$(System.ArtifactsDirectory)'
 
-  - task: AzureRmWebAppDeployment@4
+  - task: AzureRmWebAppDeployment@3
     displayName: 'Azure App Service Deploy: $(appName)'
     inputs:
       azureSubscription: ${{ parameters.serviceConnection }}

--- a/yaml/stages/findproviderapi-master-stage.yml
+++ b/yaml/stages/findproviderapi-master-stage.yml
@@ -22,6 +22,7 @@ stages:
       environmentId: d01
       sharedEnvironmentId: d01
       serviceConnection: $(devServiceConnection)
+      applicationName: fprapi
       variableTemplates: 
         - ./Automation/variables/vars-non-prd.yml@devopsTemplates
 ######################## TEST ##############################################
@@ -43,6 +44,7 @@ stages:
       environmentId: t01
       sharedEnvironmentId: t01
       serviceConnection: $(testServiceConnection)
+      applicationName: fprapi
       variableTemplates: 
         - ./Automation/variables/vars-non-prd.yml@devopsTemplates
 ######################## Pre Prod ##############################################
@@ -65,6 +67,7 @@ stages:
       environmentId: p02
       sharedEnvironmentId: p02
       serviceConnection: $(prodServiceConnection)
+      applicationName: fprapi
       variableTemplates: 
         - ./Automation/variables/vars-non-prd.yml@devopsTemplates
 # ######################## Prod ##############################################
@@ -87,5 +90,6 @@ stages:
       environmentId: p01
       sharedEnvironmentId: p01
       serviceConnection: $(prodServiceConnection)
+      applicationName: fprapi
       variableTemplates: 
         - ./Automation/variables/vars-prd.yml@devopsTemplates

--- a/yaml/stages/findproviderapi-stage.yml
+++ b/yaml/stages/findproviderapi-stage.yml
@@ -13,6 +13,8 @@ parameters:
   type: string
 - name: variableTemplates
   type: object
+- name: applicationName
+  type: string
 
 stages:
 - stage: Deploy_${{parameters.environmentId}}
@@ -34,6 +36,11 @@ stages:
       value: ${{parameters.environmentTagName}}
     - '${{ each variableTemplate in parameters.variableTemplates }}':
       - template: '${{variableTemplate}}'
+    - name: SharedBaseName
+      value: "s126${{parameters.sharedEnvironmentId}}-${{parameters.applicationName}}"
+    - name: SharedResourceGroup
+      value: '$(SharedBaseName)-shared' 
+
 
   displayName: '${{parameters.environmentName}} [${{parameters.environmentId}}] deployment'
   jobs:
@@ -53,6 +60,16 @@ stages:
     parameters:
       serviceConnection: ${{ parameters.serviceConnection }}
       sharedEnvironmentId: ${{ parameters.sharedEnvironmentId }}
+      environmentName: ${{parameters.environmentName}}
+      ConfigurationSecrets:
+        ApiSettings_ApiKey: $(ApiSettings_ApiKey)
+        ApiSettings_AppId: $(ApiSettings_AppId)
+        CourseDirectoryApiSettings_ApiKey: $(CourseDirectoryApiSettings_ApiKey)
+        DfeSignIn_ApiSecret: $(DfeSignIn_ApiSecret)
+        DfeSignIn_ClientSecret: $(DfeSignIn_ClientSecret)
+        EmailSettings_GovNotifyApiKey: $(EmailSettings_GovNotifyApiKey)
+        SQLServerAdminPassword: $(SQLServerAdminPassword)
+        GoogleMapsApiSettings_ApiKey: $(GoogleMapsApiSettings_ApiKey)
 
   - template: ../jobs/findproviderapi-publish-site-job.yml
     parameters:


### PR DESCRIPTION
The old custom pipeline task which generates application config was using depreciated PowerShell modules, so the task has been replaced with PowerShell scripts. The scripts have pulled directly from AS and have only had a small modification to ensure the required modules are installed due to T Levels not using custom images for the self-hosted agents.

PR for the scripts being added can be found here: https://github.com/DFE-Digital/operations-devops-tools/pull/32

**Additional changes**

- RedisConnectionString added to ARM output instead of forming it in an inline script, ensuring the config is generated the same way as the other T Levels services
- The AzureRmWebAppDeployment task has been reverted to version 3 due to the later version causing intermittent issues with app service slot swapping