### PR TITLE
Fix Capitalisation for Parameter Metadata Error

### DIFF
--- a/yaml/jobs/findproviderapi-infrastructure-job.yml
+++ b/yaml/jobs/findproviderapi-infrastructure-job.yml
@@ -53,7 +53,7 @@ jobs:
             -configStorageAccountName "$(ConfigStorageAccountName)"
             -apiCustomHostName "$(ApiCustomHostName)"
             -apiCertificateName "$(ApiCertificateName)"
-            -uiCustomHostName "$(ConnectCustomHostName)"
+            -uiCustomHostname "$(ConnectCustomHostName)"
             -uiCertificateName "$(ConnectCertificateName)"
             -ipSecurityRestrictions $(ipSecurityRestrictions)'
           


### PR DESCRIPTION
Fix capitalisation of ARM output parameter to ensure pipeline does not throw metadata related errors that have started occurring.