### PR TITLE
Standardise Config Variable Naming Convention

### DIFF
--- a/config/Sfa.Tl.Find.Provider.Api.schema.json
+++ b/config/Sfa.Tl.Find.Provider.Api.schema.json
@@ -33,7 +33,7 @@
         "BaseUri": {
           "minLength": 1,
           "type": "string",
-          "environmentVariable": "CourseDirectoryApiSettings_BaseUri"
+          "environmentVariable": "CourseDirectoryApiSettingsBaseUri"
         },
         "ApiKey": {
           "minLength": 1,
@@ -56,11 +56,11 @@
         },
         "DeliveryStatusToken": {
           "type": "string",
-          "environmentVariable": "EmailSettings_DeliveryStatusToken"
+          "environmentVariable": "EmailSettingsDeliveryStatusToken"
         },
         "SupportEmailAddress": {
           "type": "string",
-          "environmentVariable": "EmailSettings_SupportEmailAddress"
+          "environmentVariable": "EmailSettingsSupportEmailAddress"
         }
       },
       "additionalProperties": false,
@@ -73,39 +73,39 @@
       "properties": {
         "CleanupJobSchedule": {
           "type": "string",
-          "environmentVariable": "EmployerInterestSettings_CleanupJobSchedule"
+          "environmentVariable": "EmployerInterestSettingsCleanupJobSchedule"
         },
         "EmployerSupportSiteUri": {
           "type": "string",
-          "environmentVariable": "EmployerInterestSettings_EmployerSupportSiteUri"
+          "environmentVariable": "EmployerInterestSettingsEmployerSupportSiteUri"
         },
         "UnsubscribeEmployerUri": {
           "type": "string",
-          "environmentVariable": "EmployerInterestSettings_UnsubscribeEmployerUri"
+          "environmentVariable": "EmployerInterestSettingsUnsubscribeEmployerUri"
         },
         "ExtendEmployerUri": {
           "type": "string",
-          "environmentVariable": "EmployerInterestSettings_ExtendEmployerUri"
+          "environmentVariable": "EmployerInterestSettingsExtendEmployerUri"
         },
         "ExpiryNotificationDays": {
           "type": "integer",
-          "environmentVariable": "EmployerInterestSettings_ExpiryNotificationDays"
+          "environmentVariable": "EmployerInterestSettingsExpiryNotificationDays"
         },
         "MaximumExtensions": {
           "type": "integer",
-          "environmentVariable": "EmployerInterestSettings_MaximumExtensions"
+          "environmentVariable": "EmployerInterestSettingsMaximumExtensions"
         },
         "RegisterInterestUri": {
           "type": "string",
-          "environmentVariable": "EmployerInterestSettings_RegisterInterestUri"
+          "environmentVariable": "EmployerInterestSettingsRegisterInterestUri"
         },
         "RetentionDays": {
           "type": "integer",
-          "environmentVariable": "EmployerInterestSettings_RetentionDays"
+          "environmentVariable": "EmployerInterestSettingsRetentionDays"
         },
         "SearchRadius": {
           "type": "integer",
-          "environmentVariable": "EmployerInterestSettings_SearchRadius"
+          "environmentVariable": "EmployerInterestSettingsSearchRadius"
         }
       },
       "additionalProperties": false,
@@ -119,7 +119,7 @@
         },
         "BaseUri": {
           "type": "string",
-          "environmentVariable": "GoogleMapsApiSettings_BaseUri"
+          "environmentVariable": "GoogleMapsApiSettingsBaseUri"
         }
       },
       "additionalProperties": false,
@@ -130,7 +130,7 @@
         "BaseUri": {
           "minLength": 1,
           "type": "string",
-          "environmentVariable": "PostcodeApiSettings_BaseUri"
+          "environmentVariable": "PostcodeApiSettingsBaseUri"
         }
       },
       "additionalProperties": false,
@@ -144,19 +144,19 @@
         "ConnectSiteUri": {
           "minLength": 1,
           "type": "string",
-          "environmentVariable": "ProviderSettings_ConnectSiteUri"
+          "environmentVariable": "ProviderSettingsConnectSiteUri"
         },
         "NotificationEmailImmediateSchedule": {
           "type": "string",
-          "environmentVariable": "ProviderSettings_NotificationEmailImmediateSchedule"
+          "environmentVariable": "ProviderSettingsNotificationEmailImmediateSchedule"
         },
         "NotificationEmailDailySchedule": {
           "type": "string",
-          "environmentVariable": "ProviderSettings_NotificationEmailDailySchedule"
+          "environmentVariable": "ProviderSettingsNotificationEmailDailySchedule"
         },
         "NotificationEmailWeeklySchedule": {
           "type": "string",
-          "environmentVariable": "ProviderSettings_NotificationEmailWeeklySchedule"
+          "environmentVariable": "ProviderSettingsNotificationEmailWeeklySchedule"
         }
       },
       "additionalProperties": false,

--- a/config/Sfa.Tl.Find.Provider.Web.schema.json
+++ b/config/Sfa.Tl.Find.Provider.Web.schema.json
@@ -8,22 +8,22 @@
         "MetadataAddress": {
           "minLength": 1,
           "type": "string",
-          "environmentVariable": "DfeSignIn_MetadataAddress"
+          "environmentVariable": "DfeSignInMetadataAddress"
         },
         "Audience": {
           "minLength": 1,
           "type": "string",
-          "environmentVariable": "DfeSignIn_Audience"
+          "environmentVariable": "DfeSignInAudience"
         },
         "Issuer": {
           "minLength": 1,
           "type": "string",
-          "environmentVariable": "DfeSignIn_Issuer"
+          "environmentVariable": "DfeSignInIssuer"
         },
         "ClientId": {
           "minLength": 1,
           "type": "string",
-          "environmentVariable": "DfeSignIn_ClientId"
+          "environmentVariable": "DfeSignInClientId"
         },
         "ClientSecret": {
           "minLength": 1,
@@ -33,7 +33,7 @@
         "ApiUri": {
           "minLength": 1,
           "type": "string",
-          "environmentVariable": "DfeSignIn_ApiUri"
+          "environmentVariable": "DfeSignInApiUri"
         },
         "ApiSecret": {
           "minLength": 1,
@@ -43,7 +43,7 @@
         "Timeout": {
           "minLength": 1,
           "type": "integer",
-          "environmentVariable": "DfeSignIn_Timeout"
+          "environmentVariable": "DfeSignInTimeout"
         }
       },
       "additionalProperties": false,
@@ -75,15 +75,15 @@
       "properties": {
         "EmployerSupportSiteUri": {
           "type": "string",
-          "environmentVariable": "EmployerInterestSettings_EmployerSupportSiteUri"
+          "environmentVariable": "EmployerInterestSettingsEmployerSupportSiteUri"
         },
         "RetentionDays": {
           "type": "integer",
-          "environmentVariable": "EmployerInterestSettings_RetentionDays"
+          "environmentVariable": "EmployerInterestSettingsRetentionDays"
         },
         "SearchRadius": {
           "type": "integer",
-          "environmentVariable": "EmployerInterestSettings_SearchRadius"
+          "environmentVariable": "EmployerInterestSettingsSearchRadius"
         }
       },
       "additionalProperties": false,
@@ -94,7 +94,7 @@
         "BaseUri": {
           "minLength": 1,
           "type": "string",
-          "environmentVariable": "PostcodeApiSettings_BaseUri"
+          "environmentVariable": "PostcodeApiSettingsBaseUri"
         }
       },
       "additionalProperties": false,
@@ -108,22 +108,22 @@
         "ConnectSiteUri": {
           "minLength": 1,
           "type": "string",
-          "environmentVariable": "ProviderSettings_ConnectSiteUri"
+          "environmentVariable": "ProviderSettingsConnectSiteUri"
         },
         "DefaultSearchRadius": {
           "minLength": 1,
           "type": "integer",
-          "environmentVariable": "ProviderSettings_DefaultSearchRadius"
+          "environmentVariable": "ProviderSettingsDefaultSearchRadius"
         },
         "DefaultNotificationSearchRadius": {
           "minLength": 1,
           "type": "integer",
-          "environmentVariable": "ProviderSettings_DefaultNotificationSearchRadius"
+          "environmentVariable": "ProviderSettingsDefaultNotificationSearchRadius"
         },
         "SupportSiteAccessConnectHelpUri": {
           "minLength": 1,
           "type": "string",
-          "environmentVariable": "ProviderSettings_SupportSiteAccessConnectHelpUri"
+          "environmentVariable": "ProviderSettingsSupportSiteAccessConnectHelpUri"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
This PR fixes the consistency of configuration variables across the T Levels services by ensuring they are all following the pascal case naming convention.